### PR TITLE
fix: change Node.js default path for artifacts

### DIFF
--- a/apm-agent-auto-attach/values.yaml
+++ b/apm-agent-auto-attach/values.yaml
@@ -32,6 +32,6 @@ webhookConfig:
         JAVA_TOOL_OPTIONS: "-javaagent:/elastic/apm/agent/elastic-apm-agent.jar"
     nodejs:
       image: docker.elastic.co/observability/apm-agent-nodejs:latest
-      artifact: "/usr/agent/nodejs/node_modules/elastic-apm-node"
+      artifact: "/opt/nodejs/node_modules/elastic-apm-node"
       environment:
         NODE_OPTIONS: "-r /elastic/apm/agent/elastic-apm-node/start"


### PR DESCRIPTION
The path for the artifacts has changed in the latest `docker.elastic.co/observability/apm-agent-nodejs` Docker image 

closes https://github.com/elastic/apm-mutating-webhook/issues/39