### PR TITLE
feat: validate patch fields before sending payload

### DIFF
--- a/main.go
+++ b/main.go
@@ -72,11 +72,11 @@ func parseConfig(configPath string) (*config, error) {
 
 	for k, ac := range c.Agents {
 		if ac.Image == "" {
-			return nil, fmt.Errorf("custom agent %q is missing image", k)
+			return nil, fmt.Errorf("custom agent %q is missing 'image' value", k)
 		}
 
 		if ac.ArtifactPath == "" {
-			return nil, fmt.Errorf("custom agent %q is missing artifact", k)
+			return nil, fmt.Errorf("custom agent %q is missing 'artifact' value", k)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -149,7 +149,10 @@ func (s *server) mutate(admReview *admissionv1.AdmissionReview) error {
 	pT := admissionv1.PatchTypeJSONPatch
 	resp.PatchType = &pT
 
-	patch := createPatch(config, pod.Spec)
+	patch, err := createPatch(config, pod.Spec)
+	if err != nil {
+		return err
+	}
 
 	marshaled, err := json.Marshal(patch)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -46,6 +46,18 @@ func main() {
 		log.Fatalf("error reading config: %v", err)
 	}
 
+	for k, ac := range cfg.Agents {
+		if k != "java" && k != "nodejs" {
+			if ac.Image == "" {
+				log.Fatalf("custom agent %q is missing Image", k)
+			}
+
+			if ac.ArtifactPath == "" {
+				log.Fatalf("custom agent %q is missing Artifact", k)
+			}
+		}
+	}
+
 	ss := &server{
 		l: log.Default(),
 		c: cfg.Agents,

--- a/main_test.go
+++ b/main_test.go
@@ -39,3 +39,10 @@ func TestYAMLParse(t *testing.T) {
 	assert.Contains(t, java.Environment, "ELASTIC_APM_LOG_LEVEL")
 	assert.Contains(t, java.Environment, "ELASTIC_APM_PROFILING_INFERRED_SPANS_ENABLED")
 }
+
+func TestYAMLParseBad(t *testing.T) {
+	p := "testdata/bad.yaml"
+	cfg, err := parseConfig(p)
+	require.Error(t, err)
+	require.Nil(t, cfg)
+}

--- a/main_test.go
+++ b/main_test.go
@@ -45,4 +45,9 @@ func TestYAMLParseBad(t *testing.T) {
 	cfg, err := parseConfig(p)
 	require.Error(t, err)
 	require.Nil(t, cfg)
+
+	p = "testdata/bad2.yaml"
+	cfg, err = parseConfig(p)
+	require.Error(t, err)
+	require.Nil(t, cfg)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -45,9 +45,11 @@ func TestYAMLParseBad(t *testing.T) {
 	cfg, err := parseConfig(p)
 	require.Error(t, err)
 	require.Nil(t, cfg)
+	require.Equal(t, `custom agent "java" is missing 'image' value`, err.Error())
 
 	p = "testdata/bad2.yaml"
 	cfg, err = parseConfig(p)
 	require.Error(t, err)
 	require.Nil(t, cfg)
+	require.Equal(t, `custom agent "java" is missing 'artifact' value`, err.Error())
 }

--- a/patch.go
+++ b/patch.go
@@ -192,7 +192,9 @@ func createInitContainerPatch(config agentConfig, createArray bool) (patchOperat
 	}
 
 	if errs := validation.IsDNS1123Label(agentInitContainer.Name); len(errs) != 0 {
-		return patchOperation{}, fmt.Errorf("init container name (%s) is not a valid DNS_LABEL: %v", agentInitContainer.Name, errs)
+		return patchOperation{}, fmt.Errorf("failed to extract container name from image (%s): init container name (%s) is not a valid DNS_LABEL: %v",
+			config.Image, agentInitContainer.Name, errs,
+		)
 	}
 
 	if createArray {

--- a/patch.go
+++ b/patch.go
@@ -158,7 +158,7 @@ func generateEnvironmentVariables(config agentConfig) ([]corev1.EnvVar, error) {
 	}
 	for _, ev := range vars {
 		if errs := validation.IsEnvVarName(ev.Name); len(errs) != 0 {
-			return nil, fmt.Errorf("failed to validate variable name: %v", errs)
+			return nil, fmt.Errorf("failed to validate environment variable %q: %v", ev.Name, errs)
 		}
 	}
 	return vars, nil

--- a/patch_test.go
+++ b/patch_test.go
@@ -32,7 +32,8 @@ func TestEnvVarPatch(t *testing.T) {
 			"ELASTIC_APM_SERVER_URL": "abc",
 		},
 	}
-	vars := generateEnvironmentVariables(config)
+	vars, errs := generateEnvironmentVariables(config)
+	assert.Nil(t, errs)
 	patches := createEnvVariablesPatches(vars, true, 0)
 	assert.Len(t, patches, 1)
 	environmentVariables := patches[0].Value.([]corev1.EnvVar)
@@ -60,7 +61,8 @@ func TestEnvVarPatch(t *testing.T) {
 
 func TestAddAPMServerURLIfNotPresent(t *testing.T) {
 	config := agentConfig{Environment: map[string]string{}}
-	vars := generateEnvironmentVariables(config)
+	vars, errs := generateEnvironmentVariables(config)
+	assert.Nil(t, errs)
 	patches := createEnvVariablesPatches(vars, true, 0)
 	assert.Len(t, patches, 1)
 	environmentVariables := patches[0].Value.([]corev1.EnvVar)
@@ -77,7 +79,8 @@ func TestInitContainerPatch(t *testing.T) {
 		Image:        "stuartnelson3/agent-image:1.2.3",
 		ArtifactPath: "/tmp/artifact.jar",
 	}
-	patch := createInitContainerPatch(config, true)
+	patch, err := createInitContainerPatch(config, true)
+	assert.NoError(t, err)
 	initContainers := patch.Value.([]corev1.Container)
 	assert.Len(t, initContainers, 1)
 	ic := initContainers[0]

--- a/testdata/bad.yaml
+++ b/testdata/bad.yaml
@@ -1,7 +1,5 @@
 agents:
   java:
-    image: docker.com/elastic/agent-java:1.2.3
-    artifact: foo
     environment:
       ELASTIC_APM_SERVER_URLS: "http://34.78.173.219:8200"
       ELASTIC_APM_SERVICE_NAME: "petclinic"

--- a/testdata/bad2.yaml
+++ b/testdata/bad2.yaml
@@ -1,7 +1,6 @@
 agents:
   java:
     image: docker.com/elastic/agent-java:1.2.3
-    artifact: foo
     environment:
       ELASTIC_APM_SERVER_URLS: "http://34.78.173.219:8200"
       ELASTIC_APM_SERVICE_NAME: "petclinic"


### PR DESCRIPTION
Validate patch payload and log an error for invalid values to improve visibility in the webhook.

An invalid init container name is now logged along with the error message.

Closes https://github.com/elastic/apm-mutating-webhook/issues/38