### PR TITLE
scripts: Use `.go-version` in Docker, add targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ main
 
 .webhook
 .vscode
+bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.18-alpine AS build
+ARG GO_VERSION=1.19
+FROM golang:${GO_VERSION}-alpine AS build
 RUN apk update
 RUN apk upgrade
 ADD *go* /app/

--- a/Makefile
+++ b/Makefile
@@ -2,25 +2,57 @@ REPO?=apm
 NAME?=webhook
 TAG?=latest
 
+GO_LICENSER_VERSION?=v0.4.0
+GO_LICENSER=github.com/elastic/go-licenser@$(GO_LICENSER_VERSION)
+GO_CI_LINT_VERSION?=v1.48.0
+GO_CI_LINT=github.com/golangci/golangci-lint/cmd/golangci-lint@$(GO_CI_LINT_VERSION)
+
+export HELM_INSTALL_DIR=$(PWD)/bin
+HELM=$(HELM_INSTALL_DIR)/helm
+HELM_CHART?=./apm-agent-auto-attach
+HELM_CHART_NAME?=dev-apm-attach
+
 .PHONY: gen-notice
 gen-notice:
 	@bash ./scripts/notice.sh
 
 check-licenses:
-	go install github.com/elastic/go-licenser@v0.4.0
-	go run github.com/elastic/go-licenser@v0.4.0 -d .
-	go run github.com/elastic/go-licenser@v0.4.0 -d -ext .java .
-	go run github.com/elastic/go-licenser@v0.4.0 -d -ext .js .
+	go run $(GO_LICENSER) -d .
+	go run $(GO_LICENSER) -d -ext .java .
+	go run $(GO_LICENSER) -d -ext .js .
 
 update-licenses:
-	go install github.com/elastic/go-licenser@v0.4.0
-	go run github.com/elastic/go-licenser@v0.4.0 .
-	go run github.com/elastic/go-licenser@v0.4.0 -ext .java .
+	go run $(GO_LICENSER) .
+	go run $(GO_LICENSER) -ext .java .
 
 lint:
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.48.0 version
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.48.0 run
+	go run $(GO_CI_LINT) version
+	go run $(GO_CI_LINT) run
 
 .webhook: *.go Dockerfile
-	docker build -t $(REPO)/$(NAME):$(TAG) .
-	touch $@
+	docker build --build-arg GO_VERSION=$(shell cat .go-version) -t $(REPO)/$(NAME):$(TAG) .
+	@touch $@
+
+bin:
+	@ mkdir -p $@
+
+$(HELM): bin
+	@curl -fsSL -o bin/get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+	@chmod u+x bin/get_helm.sh
+	@env USE_SUDO=false ./bin/get_helm.sh
+
+.PHONY: clean
+clean:
+	@ rm -rf .webhook bin
+
+.PHONY: uninstall-chart
+uninstall-chart: $(HELM)
+	@ $(HELM) uninstall $(HELM_CHART_NAME)
+
+.PHONY: install-chart
+install-chart: $(HELM)
+	@ $(HELM) upgrade $(HELM_CHART_NAME) $(HELM_CHART) --install
+
+.PHONY: show-version
+show-version:
+	@echo v$(shell grep version: apm-agent-auto-attach/Chart.yaml | cut -d':' -f2 | tr -d '"'  | tr -d ' ')


### PR DESCRIPTION
Adds a few targets which should make it easier to develop and test the helm chart and the mutating webhook. Also modifies the Dockerfile to use the Go version set in `.go-version` as the Docker image, simplifying the Go version management.
