### PR TITLE
ci: enable release for tags

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -10,6 +10,8 @@ pipeline {
     JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
     PIPELINE_LOG_LEVEL = 'INFO'
     RELEASE_URL_MESSAGE = "(<https://github.com/elastic/${env.REPO}/releases/tag/${env.TAG_NAME}|${env.TAG_NAME}>)"
+    NOTIFY_TO = "build-apm+${env.REPO}@elastic.co"
+    SLACK_CHANNEL = '#apm-agent-php'
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -107,14 +109,8 @@ pipeline {
         }
       }
     }
-    stage('release') {
-      environment {
-        DOCKER_SECRET = 'secret/apm-team/ci/docker-registry/prod'
-        DOCKER_REGISTRY = 'docker.elastic.co'
-      }
-      options {
-        skipDefaultCheckout()
-      }
+    stage('Release') {
+      options { skipDefaultCheckout() }
       when {
         beforeAgent true
         tag pattern: 'v\\d+.*', comparator: 'REGEXP'
@@ -124,7 +120,6 @@ pipeline {
         unstash 'source'
         dir("${BASE_DIR}"){
           withMageEnv(){
-            dockerLogin(secret: env.DOCKER_SECRET, registry: env.DOCKER_REGISTRY)
             echo 'TBD'
           }
         }
@@ -132,6 +127,9 @@ pipeline {
       post {
         success {
           notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Release *${env.TAG_NAME}* has been published", body: "Build: (<${env.RUN_DISPLAY_URL}|here>)\nRelease URL: ${env.RELEASE_URL_MESSAGE}")
+        }
+        failure {
+          notifyStatus(slackStatus: 'danger', subject: "[${env.REPO}] Release *${env.TAG_NAME}* failed", body: "Build: (<${env.RUN_DISPLAY_URL}|here>)\nRelease URL: ${env.RELEASE_URL_MESSAGE}")
         }
       }
     }
@@ -141,4 +139,13 @@ pipeline {
       notifyBuildResult(prComment: true)
     }
   }
+}
+
+def notifyStatus(def args = [:]) {
+  releaseNotification(slackChannel: "${env.SLACK_CHANNEL}",
+                      slackColor: args.slackStatus,
+                      slackCredentialsId: 'jenkins-slack-integration-token',
+                      to: "${env.NOTIFY_TO}",
+                      subject: args.subject,
+                      body: args.body)
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
     PIPELINE_LOG_LEVEL = 'INFO'
     RELEASE_URL_MESSAGE = "(<https://github.com/elastic/${env.REPO}/releases/tag/${env.TAG_NAME}|${env.TAG_NAME}>)"
     NOTIFY_TO = "build-apm+${env.REPO}@elastic.co"
-    SLACK_CHANNEL = '#apm-agent-php'
+    SLACK_CHANNEL = '#apm-server'
     DOCKER_IMAGE_NAME = 'apm-attacher'
     DOCKER_SECRET = 'secret/apm-team/ci/docker-registry/prod'
     DOCKER_REGISTRY = 'docker.elastic.co'

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -118,6 +118,15 @@ pipeline {
             echo 'TBD'
           }
         }
+        stage('Release Notes') {
+          steps {
+            withGhEnv(forceInstallation: true, version: '2.4.0') {
+              dir("${BASE_DIR}"){
+                cmd(label: 'make release-notes', script: 'make -C .ci release-notes')
+              }
+            }
+          }
+        }
       }
       post {
         success {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -113,6 +113,11 @@ pipeline {
             publishDockerImage(imageName: "${env.DOCKER_IMAGE_NAME}", imageTag: "${env.TAG_NAME}")
           }
         }
+        stage('Helm') {
+          steps {
+            echo 'TBD'
+          }
+        }
       }
       post {
         success {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -97,7 +97,7 @@ pipeline {
     stage('Package') {
       steps {
         withGithubNotify(context: 'Package') {
-          publishDockerImage(imageName: "${env.DOCKER_IMAGE_NAME}", label: "${env.GIT_BASE_COMMIT}", shortGitSha: true)
+          publishDockerImage(imageName: "${env.DOCKER_IMAGE_NAME}", imageTag: "${env.GIT_BASE_COMMIT}", shortGitSha: true)
         }
       }
     }
@@ -110,7 +110,7 @@ pipeline {
       stages {
         stage('Docker') {
           steps {
-            publishDockerImage(imageName: "${env.DOCKER_IMAGE_NAME}", label: "${env.GIT_BASE_COMMIT}")
+            publishDockerImage(imageName: "${env.DOCKER_IMAGE_NAME}", imageTag: "${env.GIT_BASE_COMMIT}")
           }
         }
       }
@@ -132,15 +132,15 @@ pipeline {
 }
 
 def publishDockerImage(def args = [:]) {
-  def dockerImageName = args.imageName
-  def label = args.label
+  def imageName = args.imageName
+  def imageTag = args.imageTag
   def shortGitSha = args.get('shortGitSha', false)
   deleteDir()
   unstash 'source'
   dir("${BASE_DIR}"){
     withMageEnv(){
       dockerLogin(secret: env.DOCKER_SECRET, registry: env.DOCKER_REGISTRY)
-      sh(label: 'Package & Push', script: "./.ci/docker-package-push.sh ${env.DOCKER_REGISTRY}/observability ${dockerImageName} ${label} ${shortGitSha}")
+      sh(label: 'Package & Push', script: "./.ci/docker-package-push.sh ${env.DOCKER_REGISTRY}/observability ${imageName} ${imageTag} ${shortGitSha}")
     }
   }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -12,6 +12,9 @@ pipeline {
     RELEASE_URL_MESSAGE = "(<https://github.com/elastic/${env.REPO}/releases/tag/${env.TAG_NAME}|${env.TAG_NAME}>)"
     NOTIFY_TO = "build-apm+${env.REPO}@elastic.co"
     SLACK_CHANNEL = '#apm-agent-php'
+    DOCKER_IMAGE_NAME = 'apm-attacher'
+    DOCKER_SECRET = 'secret/apm-team/ci/docker-registry/prod'
+    DOCKER_REGISTRY = 'docker.elastic.co'
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -92,20 +95,9 @@ pipeline {
       }
     }
     stage('Package') {
-      environment {
-        DOCKER_SECRET = 'secret/apm-team/ci/docker-registry/prod'
-        DOCKER_REGISTRY = 'docker.elastic.co'
-      }
       steps {
         withGithubNotify(context: 'Package') {
-          deleteDir()
-          unstash 'source'
-          dir("${BASE_DIR}"){
-            withMageEnv(){
-              dockerLogin(secret: env.DOCKER_SECRET, registry: env.DOCKER_REGISTRY)
-              sh(label: 'Package & Push', script: "./.ci/docker-package-push.sh ${env.DOCKER_REGISTRY}/observability ${env.REPO} ${env.GIT_BASE_COMMIT}")
-            }
-          }
+          publishDockerImage(imageName: "${env.DOCKER_IMAGE_NAME}", label: "${env.GIT_BASE_COMMIT}")
         }
       }
     }
@@ -115,12 +107,10 @@ pipeline {
         beforeAgent true
         tag pattern: 'v\\d+.*', comparator: 'REGEXP'
       }
-      steps {
-        deleteDir()
-        unstash 'source'
-        dir("${BASE_DIR}"){
-          withMageEnv(){
-            echo 'TBD'
+      stages {
+        stage('Docker') {
+          steps {
+            publishDockerImage(imageName: "${env.DOCKER_IMAGE_NAME}", label: "${env.GIT_BASE_COMMIT}")
           }
         }
       }
@@ -137,6 +127,19 @@ pipeline {
   post {
     cleanup {
       notifyBuildResult(prComment: true)
+    }
+  }
+}
+
+def publishDockerImage(def args = [:]) {
+  def dockerImageName = args.imageName
+  def label = args.label
+  deleteDir()
+  unstash 'source'
+  dir("${BASE_DIR}"){
+    withMageEnv(){
+      dockerLogin(secret: env.DOCKER_SECRET, registry: env.DOCKER_REGISTRY)
+      sh(label: 'Package & Push', script: "./.ci/docker-package-push.sh ${env.DOCKER_REGISTRY}/observability ${dockerImageName} ${label}")
     }
   }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -97,7 +97,7 @@ pipeline {
     stage('Package') {
       steps {
         withGithubNotify(context: 'Package') {
-          publishDockerImage(imageName: "${env.DOCKER_IMAGE_NAME}", label: "${env.GIT_BASE_COMMIT}")
+          publishDockerImage(imageName: "${env.DOCKER_IMAGE_NAME}", label: "${env.GIT_BASE_COMMIT}", shortGitSha: true)
         }
       }
     }
@@ -134,12 +134,13 @@ pipeline {
 def publishDockerImage(def args = [:]) {
   def dockerImageName = args.imageName
   def label = args.label
+  def shortGitSha = args.get('shortGitSha', false)
   deleteDir()
   unstash 'source'
   dir("${BASE_DIR}"){
     withMageEnv(){
       dockerLogin(secret: env.DOCKER_SECRET, registry: env.DOCKER_REGISTRY)
-      sh(label: 'Package & Push', script: "./.ci/docker-package-push.sh ${env.DOCKER_REGISTRY}/observability ${dockerImageName} ${label}")
+      sh(label: 'Package & Push', script: "./.ci/docker-package-push.sh ${env.DOCKER_REGISTRY}/observability ${dockerImageName} ${label} ${shortGitSha}")
     }
   }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
     JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
     PIPELINE_LOG_LEVEL = 'INFO'
+    RELEASE_URL_MESSAGE = "(<https://github.com/elastic/${env.REPO}/releases/tag/${env.TAG_NAME}|${env.TAG_NAME}>)"
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -103,6 +104,34 @@ pipeline {
               sh(label: 'Package & Push', script: "./.ci/docker-package-push.sh ${env.DOCKER_REGISTRY}/observability ${env.REPO} ${env.GIT_BASE_COMMIT}")
             }
           }
+        }
+      }
+    }
+    stage('release') {
+      environment {
+        DOCKER_SECRET = 'secret/apm-team/ci/docker-registry/prod'
+        DOCKER_REGISTRY = 'docker.elastic.co'
+      }
+      options {
+        skipDefaultCheckout()
+      }
+      when {
+        beforeAgent true
+        tag pattern: 'v\\d+.*', comparator: 'REGEXP'
+      }
+      steps {
+        deleteDir()
+        unstash 'source'
+        dir("${BASE_DIR}"){
+          withMageEnv(){
+            dockerLogin(secret: env.DOCKER_SECRET, registry: env.DOCKER_REGISTRY)
+            echo 'TBD'
+          }
+        }
+      }
+      post {
+        success {
+          notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Release *${env.TAG_NAME}* has been published", body: "Build: (<${env.RUN_DISPLAY_URL}|here>)\nRelease URL: ${env.RELEASE_URL_MESSAGE}")
         }
       }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -110,7 +110,7 @@ pipeline {
       stages {
         stage('Docker') {
           steps {
-            publishDockerImage(imageName: "${env.DOCKER_IMAGE_NAME}", imageTag: "${env.GIT_BASE_COMMIT}")
+            publishDockerImage(imageName: "${env.DOCKER_IMAGE_NAME}", imageTag: "${env.TAG_NAME}")
           }
         }
       }

--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -1,0 +1,16 @@
+SHELL = /bin/bash -eo pipefail
+
+.PHONY: release-notes
+release-notes: validate-branch-name
+	@gh release list
+	@gh \
+		release \
+		create $(BRANCH_NAME) \
+		--title '$(BRANCH_NAME)' \
+		--generate-notes
+
+.PHONY: validate-branch-name
+validate-branch-name:
+ifndef BRANCH_NAME
+	$(error BRANCH_NAME is undefined)
+endif

--- a/.ci/docker-package-push.sh
+++ b/.ci/docker-package-push.sh
@@ -7,15 +7,19 @@
 # - REPO: the docker repo name
 # - NAME: the docker image name
 # - TAG: the docker tag version
+# - SHORT_GIT_SHA: whether to short the git sha, aka the given TAG argument.
 
 set -euo pipefail
 
 export REPO=${1:?docker repo not set}
 export NAME=${2:?docker image name not set}
 export TAG=${3:?docker tag not set}
+export SHORT_GIT_SHA=${4:-false}
 
 # Use the short git SHA
-TAG=${TAG:0:7}
+if [ "$SHORT_GIT_SHA" == "true" ] ; then
+	TAG=${TAG:0:7}
+fi
 
 fqn="${REPO}/${NAME}:${TAG}"
 latest="${REPO}/${NAME}:latest"


### PR DESCRIPTION
#### What

CI scaffold to support the release automation, when a GitHub tag is created with the naming `v\\d+.*`, such as publishing the docker images or the helmcharts.

Default packaging will use the GIT SHA for the docker tag and for the releases it will use the git tag.
Additionally, I changed the name of the docker image to be `apm-attacher`

#### Why

One more automation in the SDLC for this project.

#### Actions

There will be some follow ups regarding:

- [x] Docker image publishing
- [x] Simple release notes in GitHub


#### Follow ups

- Helmcharts publishing


