### PR TITLE
ci: Only build/publish on non-PR, don't tag latest

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -94,13 +94,15 @@ pipeline {
         DOCKER_REGISTRY = 'docker.elastic.co'
       }
       steps {
-        withGithubNotify(context: 'Package') {
-          deleteDir()
-          unstash 'source'
-          dir("${BASE_DIR}"){
-            withMageEnv(){
-              dockerLogin(secret: env.DOCKER_SECRET, registry: env.DOCKER_REGISTRY)
-              sh(label: 'Package & Push', script: "./.ci/docker-package-push.sh ${env.DOCKER_REGISTRY}/observability ${env.REPO} ${env.GIT_BASE_COMMIT}")
+        whenFalse(isPR()) {
+          withGithubNotify(context: 'Package') {
+            deleteDir()
+            unstash 'source'
+            dir("${BASE_DIR}"){
+              withMageEnv(){
+                dockerLogin(secret: env.DOCKER_SECRET, registry: env.DOCKER_REGISTRY)
+                sh(label: 'Package & Push', script: "./.ci/docker-package-push.sh ${env.DOCKER_REGISTRY}/observability ${env.REPO} ${env.GIT_BASE_COMMIT}")
+              }
             }
           }
         }

--- a/.ci/docker-package-push.sh
+++ b/.ci/docker-package-push.sh
@@ -25,7 +25,3 @@ make .webhook
 
 echo "INFO: Push docker image ${fqn}"
 docker push "${fqn}"
-
-echo "INFO: Push docker image ${latest}"
-docker tag "${fqn}" "${latest}"
-docker push "${latest}"


### PR DESCRIPTION
Removes the docker tagging from the current git-hash built docker image to `:latest`, and disables the "Package" step for PRs.

