### PR TITLE
release: helm chart to the prod environment when a git tag release is created

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -119,7 +119,19 @@ pipeline {
         }
         stage('Helm') {
           steps {
-            echo 'TBD'
+            withCredentials([string(credentialsId: 'release-helm-charts-job', variable: 'TOKEN')]) {
+              triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
+                job: 'https://internal-ci.elastic.co/job/elastic+unified-release+main+helm-charts-publish',
+                token: TOKEN,
+                parameters: [
+                  helm_chart: "APM-Mutating-Webhook",
+                  tag_name: "${env.TAG_NAME}",
+                  repository: "prod",
+                ],
+                useCrumbCache: false,
+                useJobInfoCache: false
+              )
+            }
           }
         }
         stage('Release Notes') {


### PR DESCRIPTION
### What

Publish the helm chart to the prod environment when a git tag release is created

### Why

It was requested so no more manual actions to be done.

### Issues

Similarly done for other projects, see https://github.com/elastic/integrations/pull/3658

Requires the CI changes to be in place