### PR TITLE
docs: update name in readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ main
 .webhook
 .vscode
 bin
+
+html_docs

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# Elastic APM mutating admission webhook for Kubernetes
+# Elastic APM Attacher for Kubernetes
 
-This repository contains a webhook receiver and a helmchart for managing the receiver's lifecycle within kubernetes.
+The Elastic APM attacher for Kubernetes simplifies the instrumentation and configuration of your application pods.
+The attacher contains a webhook receiver and a helm chart that manages the receiver's lifecycle within kubernetes.
 
 ## Release State
 
@@ -8,8 +9,7 @@ The software contained in this repo is considered a **Technical Preview**, and i
 
 ## Documentation
 
-Learn more about how to simplify the APM getting started experience on Kubernetes via auto instrumentation 
-when using the [Elastic APM mutating admission webhook](https://elastic.co/guide/en/apm/guide/current/apm-mutating-admission-webhook.html).
+See [Elastic APM Attacher](https://elastic.co/guide/en/apm/guide/current/apm-mutating-admission-webhook.html) to get started.
 
 ## Getting Help
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The software contained in this repo is considered a **Technical Preview**, and i
 
 ## Documentation
 
-See [Elastic APM Attacher](https://elastic.co/guide/en/apm/guide/current/apm-mutating-admission-webhook.html) to get started.
+See [Elastic APM Attacher](https://www.elastic.co/guide/en/apm/attacher/current/index.html) to get started.
 
 ## Getting Help
 

--- a/docs/apm-mutating-webhook.asciidoc
+++ b/docs/apm-mutating-webhook.asciidoc
@@ -4,6 +4,9 @@
 :kube-admin-docs: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/
 :helm-docs:       https://helm.sh/docs/
 
+[[apm-attacher]]
+== APM Attacher
+
 preview::[]
 
 The APM attacher for Kubernetes simplifies the instrumentation and configuration of your application pods.
@@ -14,6 +17,7 @@ Kubernetes.
 
 Learn more below, or skip ahead to <<apm-get-started-webhook>>.
 
+[float]
 [[apm-webhook]]
 == Webhook
 
@@ -29,6 +33,7 @@ API server, it looks through the pod spec for a specific, user-supplied annotati
 is mutated according to the webhook receiver's configuration. This mutated object is then returned to the
 Kubernetes API server which uses it as the source of truth for the object.
 
+[float]
 [[apm-mutation]]
 == Mutation
 
@@ -45,6 +50,7 @@ auto-instrumentation with the copied agent binary
 TIP: To learn more about mutating webhooks,
 see the {kube-admin-docs}[Kubernetes Admission controller documentation].
 
+[float]
 [[apm-helm-chart]]
 == Helm chart
 
@@ -53,8 +59,6 @@ webhook receiver, including generating certificates for securing communication
 between the Kubernetes API server and the webhook receiver.
 
 TIP: To learn more about Helm charts, see the {helm-docs}[Helm documentation].
-
-// Break content below to a new page
 
 [[apm-get-started-webhook]]
 == Instrument and configure pods


### PR DESCRIPTION
A new name was introduced in the docs in https://github.com/elastic/apm-mutating-webhook/pull/51. This PR:

- [x] Updates the readme file to match the name used in the documentation
- [x] Updates the readme file to link the new, standalone docs for this product (introduced in https://github.com/elastic/docs/pull/2535)
- [x] Fix layout now that the standalone docs are their own book

**View the new standalone docs [here](https://www.elastic.co/guide/en/apm/attacher/current/index.html) (pre layout changes in this PR).**