### PR TITLE
Auto attach .NET APM agent

### DIFF
--- a/charts/apm-attacher/values.yaml
+++ b/charts/apm-attacher/values.yaml
@@ -35,3 +35,12 @@ webhookConfig:
       artifact: "/opt/nodejs/node_modules/elastic-apm-node"
       environment:
         NODE_OPTIONS: "-r /elastic/apm/agent/elastic-apm-node/start"
+    dotnet:
+      image: docker.elastic.co/observability/apm-agent-dotnet:latest
+      artifact: "/usr/agent/apm-dotnet-agent"
+      environment:
+        CORECLR_ENABLE_PROFILING: "1"
+        CORECLR_PROFILER: "{FA65FE15-F085-4681-9B20-95E04F6C03CC}"
+        CORECLR_PROFILER_PATH: "/usr/agent/apm-dotnet-agent/libelastic_apm_profiler.so" 
+        ELASTIC_APM_PROFILER_HOME: "/usr/agent/apm-dotnet-agent"
+        ELASTIC_APM_PROFILER_INTEGRATIONS: "/usr/agent/apm-dotnet-agent/integrations.yml"

--- a/custom.yaml
+++ b/custom.yaml
@@ -22,4 +22,8 @@ webhookConfig:
         ELASTIC_APM_SERVER_URL: "https://10.10.10.10:8200"      
         ELASTIC_APM_SERVICE_NAME: "custom"
         ELASTIC_APM_LOG_LEVEL: "info"
+    dotnet:
+        ELASTIC_APM_SERVER_URL: "https://10.10.10.10:8200"      
+        ELASTIC_APM_SERVICE_NAME: "custom"
+        ELASTIC_APM_LOG_LEVEL: "info"
 


### PR DESCRIPTION
Part of https://github.com/elastic/apm-agent-dotnet/issues/1665

I'm following https://github.com/elastic/apm-mutating-webhook/pull/31 which does the same for Node.js.

The image `docker.elastic.co/observability/apm-agent-dotnet:latest` is already published.