### PR TITLE
Add environment variable for .NET attach case

### DIFF
--- a/charts/apm-attacher/values.yaml
+++ b/charts/apm-attacher/values.yaml
@@ -44,3 +44,4 @@ webhookConfig:
         CORECLR_PROFILER_PATH: "/usr/agent/apm-dotnet-agent/libelastic_apm_profiler.so" 
         ELASTIC_APM_PROFILER_HOME: "/usr/agent/apm-dotnet-agent"
         ELASTIC_APM_PROFILER_INTEGRATIONS: "/usr/agent/apm-dotnet-agent/integrations.yml"
+        ELASTIC_APM_ACTIVATION_METHOD: "K8S"


### PR DESCRIPTION
This is a follow-up PR of #66.
To detect the case of K8S agent activation (see https://github.com/elastic/apm/pull/732/files) a new environment variable `ELASTIC_APM_ACTIVATION_METHOD` is introduced.