### PR TITLE
Add explicit marker in env for activation_method=k8s for Node.js APM agent

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,4 +1,4 @@
-Copyright 2022 Elasticsearch BV
+Copyright 2023 Elasticsearch BV
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/charts/apm-attacher/values.yaml
+++ b/charts/apm-attacher/values.yaml
@@ -35,6 +35,7 @@ webhookConfig:
       artifact: "/opt/nodejs/node_modules/elastic-apm-node"
       environment:
         NODE_OPTIONS: "-r /elastic/apm/agent/elastic-apm-node/start"
+        ELASTIC_APM_ACTIVATION_METHOD: "K8S"
     dotnet:
       image: docker.elastic.co/observability/apm-agent-dotnet:latest
       artifact: "/usr/agent/apm-dotnet-agent"


### PR DESCRIPTION
The matching change in the Node.js APM agent: https://github.com/elastic/apm-agent-nodejs/issues/3119
This will be in version elastic-apm-node@3.43.0 and later.