### PR TITLE
docs: remove SECURITY.md to fallback to org-wide security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,0 @@
-# Security Policy
-
-Thanks for your interest in the security of our products.
-Our security policy can be found at [https://www.elastic.co/community/security](https://www.elastic.co/community/security).
-
-## Reporting a Vulnerability
-
-Please send security vulnerability reports to our [public bug bounty program](https://hackerone.com/elastic) or to security@elastic.co.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,4 +4,5 @@ Thanks for your interest in the security of our products.
 Our security policy can be found at [https://www.elastic.co/community/security](https://www.elastic.co/community/security).
 
 ## Reporting a Vulnerability
-Please send security vulnerability reports to security@elastic.co.
+
+Please send security vulnerability reports to our [public bug bounty program](https://hackerone.com/elastic) or to security@elastic.co.


### PR DESCRIPTION
Align security policy with other repositories

Mention the public bug bounty program.

UPDATE: after looking into this, it seems other repositories are using the org-wide security policy from the health files repo. Remove the custom SECURITY.md to fallback to that.